### PR TITLE
Batch manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.6 - Released Mar 25, 2015
+- Added Batch manager
+- Fixed an issue on route and `DELETE`: the object is no longer mapped as a request
+- Fixed an issue on request descriptors and routes with keypath. You can now write `meetings/:meeting.itemID/privatenotes/:itemID`
+- Added reachability on `WARequestManagerProtocol` and `WAAFNetworkingRequestManager`: `isReachable`
+- When you delete an object without using routes|request descriptors, the path is parsed to get the object ID to delete. It was not deleted before
+- Fixed crashes when object requests have no success or failure blocks
+- Fixed a crash when your request descriptor have no `shouldMapBlock`
+ 
 ## 0.0.5 - Released Mar 25, 2015
 Fixed an issue with mapping progress when the object to map is empty
 

--- a/Files/WAAFNetworkingRequestManager.m
+++ b/Files/WAAFNetworkingRequestManager.m
@@ -37,6 +37,8 @@
         
         // Set a default error class
         [self setErrorClass:[WANRBasicError class]];
+        
+        [[AFNetworkReachabilityManager sharedManager] startMonitoring];
     }
     
     return self;
@@ -110,6 +112,10 @@
                                    }];
     
     [dataTask resume];
+}
+
+- (BOOL)isReachable {
+    return [[AFNetworkReachabilityManager sharedManager] isReachable] || [AFNetworkReachabilityManager sharedManager].networkReachabilityStatus == AFNetworkReachabilityStatusUnknown;
 }
 
 - (void)addAPIHeadersToRequest:(NSMutableURLRequest *)request extraHeaders:(NSDictionary *)extraHeaders {

--- a/Files/WABatchCache.h
+++ b/Files/WABatchCache.h
@@ -1,0 +1,43 @@
+//
+//  WABatchCache.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+@import Foundation;
+
+@class WABatchObject;
+
+/**
+ *  A persistent cache used to store the offline batch objects enqueued and waiting to be synced to the server
+ *  Disclaimer: you have absolutely no reason to use it
+ */
+@interface WABatchCache : NSObject
+
+/**
+ *  Add a batch object to the cache. Will automatically increment the id
+ *
+ *  @param batchObject a batch object to enqueue
+ */
+- (void)addBatchObject:(WABatchObject *)batchObject;
+
+/**
+ *  Remove objects from cache store
+ *
+ *  @param batchObjects the objects to remove
+ */
+- (void)removeBatchObjects:(NSArray <WABatchObject *>*)batchObjects;
+
+/**
+ *  Completely drop the database. Also resets the auto increment id
+ */
+- (void)dropDatabase;
+
+/**
+ *  The batch objects on cache
+ */
+@property (nonatomic, readonly) NSArray *batchObjects;
+
+@end

--- a/Files/WABatchCache.m
+++ b/Files/WABatchCache.m
@@ -1,0 +1,99 @@
+//
+//  WABatchCache.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchCache.h"
+#import "WABatchObject.h"
+
+#import "WANetworkRoutingMacros.h"
+
+@interface WABatchCache ()
+
+@property (nonatomic, strong) NSMutableArray *mBatchObjects;
+@property (nonatomic, assign) NSInteger      maxObjectID;
+
+@end
+
+@implementation WABatchCache
+
+static NSString *kBatchObjectsKey  = @"kBatchObjectsKey";
+static NSString *kBatchMaxObjectID = @"kBatchMaxObjectID";
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [self loadData];
+    }
+    
+    return self;
+}
+
+- (void)addBatchObject:(WABatchObject *)batchObject {
+    WANRClassParameterAssert(batchObject, WABatchObject);
+    
+    self.maxObjectID += 1;
+    batchObject.batchID = @(self.maxObjectID);
+    
+    [self.mBatchObjects addObject:batchObject];
+    
+    [self save];
+}
+
+- (void)removeBatchObjects:(NSArray<WABatchObject *> *)batchObjects {
+    [self.mBatchObjects removeObjectsInArray:batchObjects];
+    
+    [self save];
+}
+
+- (void)dropDatabase {
+    [self.mBatchObjects removeAllObjects];
+    self.maxObjectID = 0;
+    [[NSFileManager defaultManager] removeItemAtPath:[[self class] archiveFilePath] error:nil];
+}
+
+- (NSArray *)batchObjects {
+    return [self.mBatchObjects copy];
+}
+
+#pragma mark - File management
+
++ (NSString *)libraryDocumentsDirectory {
+    return [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+}
+
++ (NSString *)archiveFilePath {
+    return [[self libraryDocumentsDirectory] stringByAppendingPathComponent:@"WABatchManager/batchData.archive"];
+}
+
+- (void)save {
+    NSMutableData *data = [NSMutableData data];
+    NSKeyedArchiver *coder = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
+    [coder encodeObject:self.batchObjects forKey:kBatchObjectsKey];
+    [coder encodeObject:@(self.maxObjectID) forKey:kBatchMaxObjectID];
+    [coder finishEncoding];
+    
+    NSString *path = [[self class] archiveFilePath];
+    
+    [[NSFileManager defaultManager] createDirectoryAtPath:[path stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
+
+    BOOL saved = [data writeToFile:path atomically:YES];
+    WANRParameterAssert(saved);
+}
+
+- (void)loadData {
+    NSData *archiveData        = [NSData dataWithContentsOfFile:[[self class] archiveFilePath]];
+    NSKeyedUnarchiver *decoder = [[NSKeyedUnarchiver alloc] initForReadingWithData:archiveData];
+    
+    self.mBatchObjects = [[decoder decodeObjectForKey:kBatchObjectsKey] mutableCopy];
+    self.maxObjectID   = [[decoder decodeObjectForKey:kBatchMaxObjectID] integerValue];
+    
+    if (!self.mBatchObjects) {
+        self.mBatchObjects = [NSMutableArray array];
+    }
+}
+
+@end

--- a/Files/WABatchManager.h
+++ b/Files/WABatchManager.h
@@ -1,0 +1,28 @@
+//
+//  WABatchManager.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchManagerProtocol.h"
+
+@class WANetworkRoute;
+
+/**
+ A default implementation for `WABatchManagerProtocol`. See the README for the server specifications.
+ */
+@interface WABatchManager : NSObject <WABatchManagerProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ *  Add a route describing the request which can be enqueued
+ *
+ *  @param route the route allowed to be automatically batched if offline
+ */
+- (void)addRouteToBatchIfOffline:(WANetworkRoute *)route;
+
+@end

--- a/Files/WABatchManager.m
+++ b/Files/WABatchManager.m
@@ -1,0 +1,282 @@
+//
+//  WABatchManager.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchManager.h"
+
+#import "WABatchCache.h"
+#import "WABatchObject.h"
+#import "WABatchSession.h"
+#import "WAObjectRequest.h"
+#import "WAObjectResponse.h"
+#import "WAURLResponse.h"
+#import "WABatchResponse.h"
+
+#import "WANetworkRoute.h"
+#import "WANetworkRoutePattern.h"
+
+#import "WANetworkRoutingMacros.h"
+
+@interface WABatchManager ()
+
+@property (nonatomic, strong) WABatchCache *cache;
+@property (nonatomic, strong) NSMutableSet<WANetworkRoute *> *offlineRoutes;
+@property (nonatomic, strong) NSString *batchPath;
+@property (nonatomic, assign) NSUInteger batchLimit;
+
+@property (nonatomic, assign, getter=isFlushing) BOOL flushing;
+
+@end
+
+@implementation WABatchManager
+@synthesize delegate = _delegate;
+@synthesize offlineFlushFailureBlock = _offlineFlushFailureBlock;
+@synthesize offlineFlushSuccessBlock = _offlineFlushSuccessBlock;
+
+- (instancetype)initWithBatchPath:(NSString *)batchPath limit:(NSUInteger)limit {
+    WANRClassParameterAssert(batchPath, NSString);
+    WANRParameterAssert(limit > 0);
+    
+    self = [super init];
+    
+    if (self) {
+        self->_cache         = [[WABatchCache alloc] init];
+        self->_offlineRoutes = [NSMutableSet set];
+        self->_batchPath     = batchPath;
+        self->_batchLimit    = limit;
+    }
+    
+    return self;
+}
+
++ (instancetype)batchManagerWithBatchPath:(NSString *)batchPath limit:(NSUInteger)limit {
+    return [[self alloc] initWithBatchPath:batchPath limit:limit];
+}
+
+#pragma mark - WABatchManagerProtocol
+
+#pragma mark Offline
+
+- (BOOL)needsFlushing {
+    return
+    (([[self.cache batchObjects] count] == 0) ? NO : YES)
+    &&
+    !self.isFlushing;
+}
+
+- (void)flushDataWithCompletion:(void (^)(BOOL success))completion {
+    
+    if (![self needsFlushing]) {
+        if (completion) {
+            completion(YES);
+        }
+        return;
+    }
+    
+    NSArray <WABatchObject *> *batchObjects = [self.cache batchObjects];
+    if ([batchObjects count] > self.batchLimit) {
+        batchObjects = [batchObjects subarrayWithRange:NSMakeRange(0, self.batchLimit)];
+    }
+    
+    WABatchSession *batchSession = [WABatchSession new];
+    for (WABatchObject *batchObject in batchObjects) {
+        [batchSession addBatchObject:batchObject];
+    }
+    
+    self.flushing = YES;
+    
+    wanrWeakify(self);
+    [self sendBatchSession:batchSession
+              successBlock:^(id <WABatchManagerProtocol> batchManager, NSArray<WABatchResponse *> *batchResponses) {
+                  wanrStrongify(self);
+                  self.flushing = NO;
+                  
+                  // Remove the batch objects
+                  [self.cache removeBatchObjects:batchObjects];
+                  
+                  // Tell something that we sent a batch session
+                  if (self.offlineFlushSuccessBlock) {
+                      self.offlineFlushSuccessBlock(batchManager, batchResponses);
+                  }
+                  
+                  // If we still needs flushing, continue
+                  if ([self needsFlushing]) {
+                      [self flushDataWithCompletion:completion];
+                  }
+                  else {
+                      // We, the flush is a success!
+                      if (completion) {
+                          completion(YES);
+                      }
+                  }
+              } failureBlock:^(id <WABatchManagerProtocol> batchManager, WAObjectRequest *request, WAObjectResponse *response, id<WANRErrorProtocol> error) {
+                  wanrStrongify(self);
+                  self.flushing = NO;
+                  
+                  if (self.offlineFlushFailureBlock) {
+                      self.offlineFlushFailureBlock(batchManager, request, response, error);
+                  }
+                  
+                  if (completion) {
+                      completion(NO);
+                  }
+              }];
+}
+
+- (BOOL)canEnqueueOfflineRequest:(WAObjectRequest *)request {    
+    __block BOOL matches = NO;
+    
+    [self.offlineRoutes enumerateObjectsUsingBlock:^(WANetworkRoute *obj, BOOL * _Nonnull stop) {
+        BOOL correctMethod = obj.method & request.method;
+        if (correctMethod) {
+            BOOL samePath = [obj.pathPattern isEqualToString:request.path];
+            if (!samePath && [obj.pathPattern rangeOfString:WANetworkRoutePatternObjectPrefix].location != NSNotFound) {
+                WANetworkRoutePattern *pattern = [[WANetworkRoutePattern alloc] initWithPattern:obj.pathPattern];
+                samePath = [pattern matchesRoute:request.path];
+            }
+            
+            if (samePath) {
+                matches = YES;
+                *stop   = YES;
+            }
+        }
+    }];
+    
+    return matches;
+}
+
+- (void)enqueueOfflineRequest:(WAObjectRequest *)request {
+    NSAssert([self canEnqueueOfflineRequest:request], @"Cannot enqueue %@ for offline batch, define a route to match the pattern", request.path);
+    
+    [self.cache addBatchObject:[self batchObjectFromRequest:request]];
+}
+
+- (void)reset {
+    [self.cache dropDatabase];
+}
+
+#pragma mark Batch session
+
+- (void)sendBatchSession:(WABatchSession *)session successBlock:(WABatchManagerSuccess)successBlock failureBlock:(WABatchManagerFailure)failureBlock {
+    NSAssert(self.delegate, @"Delegate should no be nil, batch request needs to be handled");
+    
+    // Build the parameters from the session
+    NSMutableArray *requestsAsDics = [NSMutableArray array];
+    
+    for (WABatchObject *batchObject in session.batchObjects) {
+        NSMutableDictionary *requestAsDic = [NSMutableDictionary dictionary];
+        requestAsDic[@"method"]           = batchObject.method;
+        requestAsDic[@"uri"]              = [batchObject.uri hasPrefix:@"/"] ? batchObject.uri : [@"/" stringByAppendingString:batchObject.uri];
+        
+        if (batchObject.parameters) {
+            // Encode it as string
+            NSData *dJSON = [NSJSONSerialization dataWithJSONObject:batchObject.parameters
+                                                            options:0
+                                                              error:nil];
+            NSString *json = [[NSString alloc] initWithData:dJSON encoding:NSUTF8StringEncoding];
+            requestAsDic[@"body"] = json;
+        }
+        
+        NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithDictionary:batchObject.headers];
+        headers[@"Content-Type"] = @"application/json";
+        requestAsDic[@"headers"] = headers;
+        
+        [requestsAsDics addObject:requestAsDic];
+    }
+    
+    WAObjectRequest *objectRequest = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodPOST
+                                                                       path:self.batchPath
+                                                                 parameters:@{@"batch": requestsAsDics}
+                                                            optionalHeaders:nil];
+    
+    wanrWeakify(self);
+    [objectRequest setCompletionBlocksWithSuccess:
+     ^(WAObjectRequest *objectRequest, WAObjectResponse *fromBatchResponse, NSArray *mappedObjects) {
+         wanrStrongify(self);
+         
+         NSArray *responses = (NSArray *)fromBatchResponse.responseObject;
+         NSMutableArray *batchResponses = [NSMutableArray array];
+         
+         // Go through all responses
+         NSUInteger index = 0;
+         
+         for (NSDictionary *dic in responses) {
+             WAObjectResponse *response = [WAObjectResponse new];
+             
+             NSString *body = dic[@"body"];
+             if ([body isEqual:[NSNull null]]) {
+                 body = nil;
+             }
+             
+             if (body) {
+                 response.responseObject = [NSJSONSerialization JSONObjectWithData:[body dataUsingEncoding:NSUTF8StringEncoding]
+                                                                           options:0
+                                                                             error:nil];
+             }
+             
+             WAURLResponse *urlResponse   = [WAURLResponse new];
+             urlResponse.statusCode       = [dic[@"code"] integerValue];
+             urlResponse.httpHeaderFields = dic[@"headers"];
+             response.urlResponse         = urlResponse;
+             
+             WABatchObject *batchObject = session.batchObjects[index];
+             WAObjectRequest *request   = [self objectRequestFromBatchObject:batchObject];
+             
+             WABatchResponse *batchResponse = [WABatchResponse new];
+             batchResponse.response         = response;
+             batchResponse.request          = request;
+             
+             [batchResponses addObject:batchResponse];
+             index++;
+         }
+         
+         [self.delegate batchManager:self haveBatchResponsesToProcess:[batchResponses copy]];
+         
+         if (successBlock) {
+             successBlock(self, [batchResponses copy]);
+         }
+     }
+                                          failure:
+     ^(WAObjectRequest *objectRequest, WAObjectResponse *response, id<WANRErrorProtocol> error) {
+         if (failureBlock) {
+             failureBlock(self, objectRequest, response, error);
+         }
+     }];
+    
+    [self.delegate batchManager:self haveBatchRequestToEnqueue:objectRequest];
+}
+#pragma mark - Helpers
+
+- (WABatchObject *)batchObjectFromRequest:(WAObjectRequest *)request {
+    WABatchObject *batchObject = [WABatchObject new];
+    batchObject.parameters     = request.parameters;
+    batchObject.headers        = request.headers;
+    batchObject.uri            = request.path;
+    batchObject.method         = WAStringFromObjectRequestMethod(request.method);
+    
+    return batchObject;
+}
+
+- (WAObjectRequest *)objectRequestFromBatchObject:(WABatchObject *)batchObject {
+    WAObjectRequest *request = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodFromString(batchObject.method)
+                                                                 path:batchObject.uri
+                                                           parameters:batchObject.parameters
+                                                      optionalHeaders:batchObject.parameters];
+    return request;
+}
+
+#pragma mark - Public methods
+
+- (void)addRouteToBatchIfOffline:(WANetworkRoute *)route {
+    WANRClassParameterAssert(route, WANetworkRoute);
+    
+    NSAssert(![self.offlineRoutes containsObject:route], @"You cannot add twice the same route");
+    
+    [self.offlineRoutes addObject:route];
+}
+
+@end

--- a/Files/WABatchManagerProtocol.h
+++ b/Files/WABatchManagerProtocol.h
@@ -1,0 +1,139 @@
+//
+//  WABatchManagerProtocol.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+@import Foundation;
+
+@class WABatchSession, WAObjectRequest, WAObjectResponse, WABatchResponse;
+@protocol WANRErrorProtocol, WABatchManagerDelegate, WABatchManagerProtocol;
+
+/**
+ *  A block called on success
+ *
+ *  @param batchManager   the batch manager triggering the event
+ *  @param batchResponses an array of batch responses which contains the request, the response and the mapped object if the mapping is configured
+ */
+typedef void (^WABatchManagerSuccess)(id <WABatchManagerProtocol> batchManager, NSArray <WABatchResponse *> *batchResponses);
+
+/**
+ *  A block called on failure
+ *
+ *  @param batchManager             the batch manager triggering the event
+ *  @param request                  the batch request
+ *  @param response                 the response from the batch request
+ *  @param <WANRErrorProtocol>error the error
+ */
+typedef void (^WABatchManagerFailure)(id <WABatchManagerProtocol> batchManager, WAObjectRequest *request, WAObjectResponse *response, id <WANRErrorProtocol>error);
+
+/**
+ This protocols defines the batch manager. The library has a default implementation `WABatchManager`.
+ The idea of the protocol is to send a batch session, but also allow some requests to be automatically enqueued if the app is offline, and then enqueued if the app comes online.
+*/
+@protocol WABatchManagerProtocol <NSObject>
+
+/**
+ *  Init the batch manager with a path and a limit.
+ *  The limit is the batch size your server can receive. If the number of objects to send is greater than the limit, then the flush will happen in several steps.
+ *
+ *  @param batchPath the path to reach the batch relative to base url
+ *  @param limit     the batch limit your server has
+ *
+ *  @return a batch manager
+ */
+- (instancetype)initWithBatchPath:(NSString *)batchPath limit:(NSUInteger)limit;
+
+/**
+ *  @see `initWithBatchPath: limit`
+ *
+ *  @param batchPath the path to reach the batch relative to base url
+ *  @param limit     the batch limit your server has
+ *
+ *  @return a batch manager
+ */
++ (instancetype)batchManagerWithBatchPath:(NSString *)batchPath limit:(NSUInteger)limit;
+
+// ———————————————————————
+// Offline management
+// ———————————————————————
+
+/**
+ *  Ask the batch manager if it needs to flush some data enqueued after offline errors
+ *
+ *  @return YES if elements needs to be flushed AND we are not flushing
+ */
+- (BOOL)needsFlushing;
+
+/**
+ *  Flush the batch data we have from offline request enqueued and synchronise with the server
+ *
+ *  @param completion a completion block called when the flush is complete.
+ */
+- (void)flushDataWithCompletion:(void(^)(BOOL success))completion;
+
+/**
+ *  Determine if a request can be enqueued or not. On `WABatchManager` implementation, you have to use `WANetworkRoute`
+ *
+ *  @param request the request which cannot be triggered because the app is offline
+ *
+ *  @return YES if the request can be enqueued
+ */
+- (BOOL)canEnqueueOfflineRequest:(WAObjectRequest *)request;
+
+/**
+ *  Enqueue for offline the request which cannot be triggered because the app is offline
+ *
+ *  @param request the request to enqueue
+ */
+- (void)enqueueOfflineRequest:(WAObjectRequest *)request;
+
+/**
+ *  Reset the database and remove all saved requests
+ */
+- (void)reset;
+
+/**
+ *  Return the flush status. If a flush is in progress, you should not send request but batch them waiting for the batch end so that the reconciliation with the server can be correct
+ *
+ *  @return YES if a flush is in progress, NO otherwise
+ */
+- (BOOL)isFlushing;
+
+// ———————————————————————
+// Classic batch
+// ———————————————————————
+
+/**
+ *  Send a batch session. Use this method if you want to perform multiple calls at the same time. For example: getting the events, the user profile, the news list after a signin. You would create a session with three GET requests
+ *
+ *  @param session      the session with the batched requests
+ *  @param successBlock a block called on success
+ *  @param failureBlock a block called on failure
+ */
+- (void)sendBatchSession:(WABatchSession *)session successBlock:(WABatchManagerSuccess)successBlock failureBlock:(WABatchManagerFailure)failureBlock;
+
+/**
+ *  A delegate for the batch. Used for communicating with the `WANetworkRoutingManager` to enqueue the request and map the responses
+ */
+@property (nonatomic, weak) id <WABatchManagerDelegate> delegate;
+
+/**
+ *  A block called on each offline batch session sent if success. Basically, you should call `neesdFlushing` to know if there are some pending offline batch objects to send.
+ */
+@property (nonatomic, copy) WABatchManagerSuccess offlineFlushSuccessBlock;
+/**
+ *  A block called on offline batch if there is any error. Note that this is the `/batch` error, not the possible errors from the batch requests themselves.
+ */
+@property (nonatomic, copy) WABatchManagerFailure offlineFlushFailureBlock;
+
+@end
+
+@protocol WABatchManagerDelegate <NSObject>
+
+- (void)batchManager:(id<WABatchManagerProtocol>)batchManager haveBatchRequestToEnqueue:(WAObjectRequest *)objectRequest;
+- (void)batchManager:(id<WABatchManagerProtocol>)batchManager haveBatchResponsesToProcess:(NSArray <WABatchResponse *>*)batchReponses;
+
+@end

--- a/Files/WABatchObject.h
+++ b/Files/WABatchObject.h
@@ -1,0 +1,22 @@
+//
+//  WABatchObject.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+@import Foundation;
+
+/**
+ *  A batch object describing a `WAObjectRequest`
+ */
+@interface WABatchObject : NSObject <NSCoding>
+
+@property (nonatomic, strong) NSNumber *batchID; // The batch ID
+@property (nonatomic, strong) NSString *method; // The method (POST GET PUT ...)
+@property (nonatomic, strong) NSString *uri; // The relative path (/items for http://someURL.com/items)
+@property (nonatomic, strong) id parameters; // The parameters
+@property (nonatomic, strong) id headers; // The headers for the specific request. Default is content type = application/json
+
+@end

--- a/Files/WABatchObject.m
+++ b/Files/WABatchObject.m
@@ -1,0 +1,34 @@
+//
+//  WABatchObject.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchObject.h"
+
+@implementation WABatchObject
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (self) {
+        self.batchID    = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(batchID))];
+        self.method     = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(method))];
+        self.uri        = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(uri))];
+        self.parameters = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(parameters))];
+        self.headers    = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(headers))];
+    }
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.batchID forKey:NSStringFromSelector(@selector(batchID))];
+    [aCoder encodeObject:self.method forKey:NSStringFromSelector(@selector(method))];
+    [aCoder encodeObject:self.uri forKey:NSStringFromSelector(@selector(uri))];
+    [aCoder encodeObject:self.parameters forKey:NSStringFromSelector(@selector(parameters))];
+    [aCoder encodeObject:self.headers forKey:NSStringFromSelector(@selector(headers))];
+}
+
+@end

--- a/Files/WABatchResponse.h
+++ b/Files/WABatchResponse.h
@@ -1,0 +1,23 @@
+//
+//  WABatchResponse.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 16-03-30.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+@import Foundation;
+
+@class WAObjectRequest, WAObjectResponse;
+
+/**
+ *  The batch response
+ *  Contains the original request, the reponse (object and status code) plus the mapped objects if a mapper is used
+ */
+@interface WABatchResponse : NSObject
+
+@property (nonatomic, strong) WAObjectRequest  *request;
+@property (nonatomic, strong) WAObjectResponse *response;
+@property (nonatomic, strong) NSArray          *mappedObjects;
+
+@end

--- a/Files/WABatchResponse.m
+++ b/Files/WABatchResponse.m
@@ -1,0 +1,13 @@
+//
+//  WABatchResponse.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 16-03-30.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchResponse.h"
+
+@implementation WABatchResponse
+
+@end

--- a/Files/WABatchSession.h
+++ b/Files/WABatchSession.h
@@ -1,0 +1,39 @@
+//
+//  WABatchSession.h
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+@import Foundation;
+
+@class WAObjectRequest, WABatchObject;
+
+/**
+ *  A batch session is an object you create if you want to send multiple calls grouped in a single one.
+ *  For example, you could have a `GET me`, a `GET meetings`, a `GET configuration` after a signin.
+ */
+@interface WABatchSession : NSObject
+
+/**
+ *  Add a request to the batch. Please note that the order does matter. See `WAObjectRequest` init method to create a request.
+ *  The request will automatically be converted to a `WABatchObject`
+ *
+ *  @param objectRequest the request to enqueue in the session
+ */
+- (void)addRequest:(WAObjectRequest *)objectRequest;
+
+/**
+ *  Same as adding a request, but you add a batch object instead. You have no reason to use this method. It is internally used in `WABatchManager` implementation.
+ *
+ *  @param batchObject the batch objct to enqueue in the session
+ */
+- (void)addBatchObject:(WABatchObject *)batchObject;
+
+/**
+ *  An array of batch objects enqueued
+ */
+@property (nonatomic, readonly) NSArray<WABatchObject *> *batchObjects;
+
+@end

--- a/Files/WABatchSession.m
+++ b/Files/WABatchSession.m
@@ -1,0 +1,54 @@
+//
+//  WABatchSession.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import "WABatchSession.h"
+#import "WANetworkRoutingMacros.h"
+
+#import "WAObjectRequest.h"
+#import "WABatchObject.h"
+
+@interface WABatchSession ()
+
+@property (nonatomic, strong) NSMutableArray<WABatchObject *> *mBatchObjects;
+
+@end
+
+@implementation WABatchSession
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self->_mBatchObjects = [NSMutableArray array];
+    }
+    
+    return self;
+}
+
+- (void)addRequest:(WAObjectRequest *)objectRequest {
+    WANRClassParameterAssert(objectRequest, WAObjectRequest);
+    
+    WABatchObject *batchObject = [WABatchObject new];
+    batchObject.parameters     = objectRequest.parameters;
+    batchObject.headers        = objectRequest.headers;
+    batchObject.uri            = objectRequest.path;
+    batchObject.method         = WAStringFromObjectRequestMethod(objectRequest.method);
+    
+    [self addBatchObject:batchObject];
+}
+
+- (void)addBatchObject:(WABatchObject *)batchObject {
+    WANRClassParameterAssert(batchObject, WABatchObject);
+ 
+    [self.mBatchObjects addObject:batchObject];
+}
+
+- (NSArray<WABatchObject *> *)batchObjects {
+    return [self.mBatchObjects copy];
+}
+
+@end

--- a/Files/WANetworkRoute.m
+++ b/Files/WANetworkRoute.m
@@ -22,6 +22,23 @@ NSString *WAStringFromObjectRequestMethod(WAObjectRequestMethod method) {
     return [NSString stringWithFormat:@"%@", [methodsAsString componentsJoinedByString:@"|"]];
 }
 
+WAObjectRequestMethod WAObjectRequestMethodFromString(NSString *method) {
+    if ([method isEqualToString:@"GET"]) {
+        return WAObjectRequestMethodGET;
+    } else if ([method isEqualToString:@"PUT"]) {
+        return WAObjectRequestMethodPUT;
+    } else if ([method isEqualToString:@"POST"]) {
+        return WAObjectRequestMethodPOST;
+    } else if ([method isEqualToString:@"HEAD"]) {
+        return WAObjectRequestMethodHEAD;
+    } else if ([method isEqualToString:@"PATCH"]) {
+        return WAObjectRequestMethodPATCH;
+    } else if ([method isEqualToString:@"DELETE"]) {
+        return WAObjectRequestMethodDELETE;
+    }
+    return -1;
+}
+
 @interface WANetworkRoute ()
 
 @property (nonatomic, strong) Class                 objectClass;
@@ -66,7 +83,7 @@ NSString *WAStringFromObjectRequestMethod(WAObjectRequestMethod method) {
         return YES;
     }
     
-    if ([self.objectClass isEqual:route.objectClass]
+    if (((!self.objectClass && !route.objectClass) || [self.objectClass isEqual:route.objectClass])
         &&
         [self.pathPattern isEqualToString:route.pathPattern]
         &&

--- a/Files/WANetworkRoutePattern.m
+++ b/Files/WANetworkRoutePattern.m
@@ -78,7 +78,7 @@ static NSString *WANetworkRoutePatternObjectEscapeString = @"\\";
                 suffix        = [pathComponent substringFromIndex:escapedCharactersRange.location + escapedCharactersRange.length];
             }
             
-            NSString *value = [[object valueForKey:parameterName] description];
+            NSString *value = [[object valueForKeyPath:parameterName] description];
             if (suffix) {
                 value = [value stringByAppendingString:suffix];
             }

--- a/Files/WANetworkRouting.h
+++ b/Files/WANetworkRouting.h
@@ -25,4 +25,8 @@
 #import "WANetworkRouter.h"
 #import "WANetworkRoute.h"
 
+#import "WABatchManager.h"
+#import "WABatchSession.h"
+#import "WABatchResponse.h"
+
 #import <WAMapping/WAMapping.h>

--- a/Files/WANetworkRoutingManager.h
+++ b/Files/WANetworkRoutingManager.h
@@ -11,10 +11,15 @@
 #import "WARequestManagerProtocol.h"
 #import "WAMappingManagerProtocol.h"
 #import "WARequestAuthenticationManagerProtocol.h"
+#import "WABatchManagerProtocol.h"
 
 #import "WANetworkRoutingUtilities.h"
 
 @class WANetworkRouter;
+
+typedef NS_ENUM(NSUInteger, WANetworkRoutingManagerError) {
+    WANetworkRoutingManagerErrorRequestBatched
+};
 
 @interface WANetworkRoutingManager : NSObject
 
@@ -28,12 +33,13 @@
  *  @param requestManager        the request manager used to fetch data from server
  *  @param mappingManager        the mapping manager used to turn json to objects
  *  @param authenticationManager the authentication manager if your API needs an authentication
+ *  @param batchManager          the batch manager if you have any batch behavior to handle
  *
  *  @return a fresh instance
  */
-- (instancetype)initWithBaseURL:(NSURL *)baseURL requestManager:(id <WARequestManagerProtocol>)requestManager mappingManager:(id <WAMappingManagerProtocol>)mappingManager authenticationManager:(id <WARequestAuthenticationManagerProtocol>)authenticationManager NS_DESIGNATED_INITIALIZER;
-// @see `initWithBaseURL: requestManager: mappingManager: authenticationManager:`
-+ (instancetype)managerWithBaseURL:(NSURL *)baseURL requestManager:(id <WARequestManagerProtocol>)requestManager mappingManager:(id <WAMappingManagerProtocol>)mappingManager authenticationManager:(id <WARequestAuthenticationManagerProtocol>)authenticationManager;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL requestManager:(id <WARequestManagerProtocol>)requestManager mappingManager:(id <WAMappingManagerProtocol>)mappingManager authenticationManager:(id <WARequestAuthenticationManagerProtocol>)authenticationManager batchManager:(id <WABatchManagerProtocol>)batchManager NS_DESIGNATED_INITIALIZER;
+// @see `initWithBaseURL: requestManager: mappingManager: authenticationManager: batchManager:`
++ (instancetype)managerWithBaseURL:(NSURL *)baseURL requestManager:(id <WARequestManagerProtocol>)requestManager mappingManager:(id <WAMappingManagerProtocol>)mappingManager authenticationManager:(id <WARequestAuthenticationManagerProtocol>)authenticationManager batchManager:(id <WABatchManagerProtocol>)batchManager;
 
 /**
  *  GET all objects on a path
@@ -267,7 +273,10 @@
 @property (nonatomic, strong, readonly ) id <WARequestManagerProtocol>               requestManager;
 @property (nonatomic, strong, readonly ) id <WARequestAuthenticationManagerProtocol> authenticationManager;
 @property (nonatomic, strong, readonly ) id <WAMappingManagerProtocol>               mappingManager;
+@property (nonatomic, strong, readonly ) id <WABatchManagerProtocol>                 batchManager;
 @property (nonatomic, strong, readonly ) WANetworkRouter                             *router;
 @property (nonatomic, strong, readwrite) NSDictionary                                *optionalHeaders;
 
 @end
+
+FOUNDATION_EXTERN NSString * const WANetworkRoutingManagerErrorDomain;

--- a/Files/WANetworkRoutingUtilities.h
+++ b/Files/WANetworkRoutingUtilities.h
@@ -23,6 +23,7 @@ typedef NS_OPTIONS(NSInteger, WAObjectRequestMethod) {
 };
 
 FOUNDATION_EXPORT NSString *WAStringFromObjectRequestMethod(WAObjectRequestMethod method);
+FOUNDATION_EXPORT WAObjectRequestMethod WAObjectRequestMethodFromString(NSString *method);
 
 @class WAObjectRequest, WAObjectResponse;
 

--- a/Files/WARequestManagerProtocol.h
+++ b/Files/WARequestManagerProtocol.h
@@ -32,4 +32,11 @@ typedef void (^WARequestManagerProgress)(WAObjectRequest *request, NSProgress *u
  */
 - (void)enqueueRequest:(WAObjectRequest *)objectRequest authenticateRequestBlock:(WARequestManagerAuthenticateRequest)authenticateRequestBlock successBlock:(WARequestManagerSuccess)successBlock failureBlock:(WARequestManagerFailure)failureBlock progress:(WARequestManagerProgress)progressBlock;
 
+/**
+ *  Returns reachability status
+ *
+ *  @return YES if reachable, NO otherwise
+ */
+- (BOOL)isReachable;
+
 @end

--- a/WANetworkRouting.podspec
+++ b/WANetworkRouting.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "WANetworkRouting"
-  s.version      = "0.0.5"
+  s.version      = "0.0.6"
   s.summary      = "A routing library to fetch objects from an API and map them to your app"
   s.homepage     = "https://github.com/Wasappli/WANetworkRouting"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Marian Paul" => "marian@wasapp.li" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/Wasappli/WANetworkRouting.git", :tag => "0.0.5" }
+  s.source       = { :git => "https://github.com/Wasappli/WANetworkRouting.git", :tag => "0.0.6" }
   s.source_files = "Files/*.{h,m}"
   s.requires_arc = true
   s.dependency   'AFNetworking', '~> 3.0'

--- a/WANetworkRouting.xcodeproj/project.pbxproj
+++ b/WANetworkRouting.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		3B220D457102AEFF2B257BB1 /* libPods-WANetworkRoutingTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DE48A9F7E1AFBF272F4C39EB /* libPods-WANetworkRoutingTests.a */; };
 		A112863FA06BAC723883769B /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8288A69B4A2CB10241A9C1C4 /* libPods.a */; };
+		E00C832B1CAC7C72004F3F1C /* WABatchResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E00C832A1CAC7C72004F3F1C /* WABatchResponse.m */; };
+		E00C832D1CAC8BDD004F3F1C /* WARoutingManagerRequestMappingBatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E00C832C1CAC8BDD004F3F1C /* WARoutingManagerRequestMappingBatchTests.m */; };
 		E01C1C971C7CB5CB00FFEF06 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E01C1C961C7CB5CB00FFEF06 /* main.m */; };
 		E01C1C9A1C7CB5CB00FFEF06 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E01C1C991C7CB5CB00FFEF06 /* AppDelegate.m */; };
 		E01C1C9D1C7CB5CB00FFEF06 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E01C1C9C1C7CB5CB00FFEF06 /* ViewController.m */; };
@@ -42,12 +44,19 @@
 		E04C8E271C9EF4CC00D51D2C /* CommentsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E04C8E261C9EF4CC00D51D2C /* CommentsTableViewController.m */; };
 		E04C8E2A1C9EF4D400D51D2C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = E04C8E291C9EF4D400D51D2C /* Comment.m */; };
 		E04C8E2D1CA0798000D51D2C /* WAProgress.m in Sources */ = {isa = PBXBuildFile; fileRef = E04C8E2C1CA0798000D51D2C /* WAProgress.m */; };
+		E063DD951CAACB5800E55764 /* WABatchSession.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DD941CAACB5800E55764 /* WABatchSession.m */; };
+		E063DD981CAACD0600E55764 /* WABatchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DD971CAACD0600E55764 /* WABatchManager.m */; };
+		E063DD9B1CAACF0A00E55764 /* WABatchCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DD9A1CAACF0A00E55764 /* WABatchCache.m */; };
+		E063DD9E1CAACF1400E55764 /* WABatchObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DD9D1CAACF1400E55764 /* WABatchObject.m */; };
+		E063DDA11CAAD47A00E55764 /* WABatchCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DDA01CAAD47A00E55764 /* WABatchCacheTests.m */; };
+		E063DDA31CAADDB000E55764 /* WABatchManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E063DDA21CAADDB000E55764 /* WABatchManagerTests.m */; };
 		E09D02F31C7D17E800938629 /* WANRBasicError.m in Sources */ = {isa = PBXBuildFile; fileRef = E09D02F21C7D17E800938629 /* WANRBasicError.m */; };
 		E09D02F51C7D1AFB00938629 /* WARoutingManagerRequestOnlyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09D02F41C7D1AFB00938629 /* WARoutingManagerRequestOnlyTests.m */; };
 		E09D02F71C7D1C4E00938629 /* EnterprisesList.json in Resources */ = {isa = PBXBuildFile; fileRef = E09D02F61C7D1C4E00938629 /* EnterprisesList.json */; };
 		E09D02F91C7D1CD300938629 /* Wasappli.json in Resources */ = {isa = PBXBuildFile; fileRef = E09D02F81C7D1CD300938629 /* Wasappli.json */; };
 		E09D02FB1C7D24AD00938629 /* WARoutingManagerRequestMappingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09D02FA1C7D24AD00938629 /* WARoutingManagerRequestMappingTests.m */; };
 		E09D02FE1C7D421100938629 /* WARoutingManagerRequestMappingRouterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09D02FD1C7D421100938629 /* WARoutingManagerRequestMappingRouterTests.m */; };
+		E0F343211CAC30CA00055D0F /* WARoutingManagerRequestBatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0F343201CAC30CA00055D0F /* WARoutingManagerRequestBatchTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +74,9 @@
 		70E6F3FE1A9A8BE187FC72D4 /* Pods-WANetworkRoutingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WANetworkRoutingTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WANetworkRoutingTests/Pods-WANetworkRoutingTests.release.xcconfig"; sourceTree = "<group>"; };
 		8288A69B4A2CB10241A9C1C4 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE48A9F7E1AFBF272F4C39EB /* libPods-WANetworkRoutingTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WANetworkRoutingTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E00C83291CAC7C72004F3F1C /* WABatchResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchResponse.h; sourceTree = "<group>"; };
+		E00C832A1CAC7C72004F3F1C /* WABatchResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchResponse.m; sourceTree = "<group>"; };
+		E00C832C1CAC8BDD004F3F1C /* WARoutingManagerRequestMappingBatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WARoutingManagerRequestMappingBatchTests.m; sourceTree = "<group>"; };
 		E01C1C921C7CB5CB00FFEF06 /* WANetworkRouting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WANetworkRouting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E01C1C961C7CB5CB00FFEF06 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		E01C1C981C7CB5CB00FFEF06 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -131,6 +143,17 @@
 		E04C8E291C9EF4D400D51D2C /* Comment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Comment.m; sourceTree = "<group>"; };
 		E04C8E2B1CA0798000D51D2C /* WAProgress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WAProgress.h; sourceTree = "<group>"; };
 		E04C8E2C1CA0798000D51D2C /* WAProgress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WAProgress.m; sourceTree = "<group>"; };
+		E063DD911CAAC96C00E55764 /* WABatchManagerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchManagerProtocol.h; sourceTree = "<group>"; };
+		E063DD931CAACB5800E55764 /* WABatchSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchSession.h; sourceTree = "<group>"; };
+		E063DD941CAACB5800E55764 /* WABatchSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchSession.m; sourceTree = "<group>"; };
+		E063DD961CAACD0600E55764 /* WABatchManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchManager.h; sourceTree = "<group>"; };
+		E063DD971CAACD0600E55764 /* WABatchManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchManager.m; sourceTree = "<group>"; };
+		E063DD991CAACF0A00E55764 /* WABatchCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchCache.h; sourceTree = "<group>"; };
+		E063DD9A1CAACF0A00E55764 /* WABatchCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchCache.m; sourceTree = "<group>"; };
+		E063DD9C1CAACF1400E55764 /* WABatchObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WABatchObject.h; sourceTree = "<group>"; };
+		E063DD9D1CAACF1400E55764 /* WABatchObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchObject.m; sourceTree = "<group>"; };
+		E063DDA01CAAD47A00E55764 /* WABatchCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchCacheTests.m; sourceTree = "<group>"; };
+		E063DDA21CAADDB000E55764 /* WABatchManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WABatchManagerTests.m; sourceTree = "<group>"; };
 		E09D02F11C7D17E800938629 /* WANRBasicError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WANRBasicError.h; sourceTree = "<group>"; };
 		E09D02F21C7D17E800938629 /* WANRBasicError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WANRBasicError.m; sourceTree = "<group>"; };
 		E09D02F41C7D1AFB00938629 /* WARoutingManagerRequestOnlyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WARoutingManagerRequestOnlyTests.m; sourceTree = "<group>"; };
@@ -138,6 +161,7 @@
 		E09D02F81C7D1CD300938629 /* Wasappli.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Wasappli.json; sourceTree = "<group>"; };
 		E09D02FA1C7D24AD00938629 /* WARoutingManagerRequestMappingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WARoutingManagerRequestMappingTests.m; sourceTree = "<group>"; };
 		E09D02FD1C7D421100938629 /* WARoutingManagerRequestMappingRouterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WARoutingManagerRequestMappingRouterTests.m; sourceTree = "<group>"; };
+		E0F343201CAC30CA00055D0F /* WARoutingManagerRequestBatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WARoutingManagerRequestBatchTests.m; sourceTree = "<group>"; };
 		E82FFD9E7F3107C38B61B5AD /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		E984CCFFE13D7E119A724EAD /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -246,6 +270,7 @@
 				E01C1CCC1C7CC00C00FFEF06 /* Response */,
 				E01C1CD31C7CD68B00FFEF06 /* Router */,
 				E01C1CDD1C7CDA0200FFEF06 /* Mapping */,
+				E063DD921CAACB3F00E55764 /* Batch */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -256,6 +281,7 @@
 				E01C1CBE1C7CB78400FFEF06 /* WARequestAuthenticationManagerProtocol.h */,
 				E01C1CBF1C7CB86200FFEF06 /* WARequestManagerProtocol.h */,
 				E01C1CC01C7CB98700FFEF06 /* WAMappingManagerProtocol.h */,
+				E063DD911CAAC96C00E55764 /* WABatchManagerProtocol.h */,
 				E01C1CC81C7CBF4000FFEF06 /* WANRErrorProtocol.h */,
 			);
 			name = Protocols;
@@ -351,8 +377,29 @@
 				E09D02F41C7D1AFB00938629 /* WARoutingManagerRequestOnlyTests.m */,
 				E09D02FA1C7D24AD00938629 /* WARoutingManagerRequestMappingTests.m */,
 				E09D02FD1C7D421100938629 /* WARoutingManagerRequestMappingRouterTests.m */,
+				E063DDA01CAAD47A00E55764 /* WABatchCacheTests.m */,
+				E063DDA21CAADDB000E55764 /* WABatchManagerTests.m */,
+				E0F343201CAC30CA00055D0F /* WARoutingManagerRequestBatchTests.m */,
+				E00C832C1CAC8BDD004F3F1C /* WARoutingManagerRequestMappingBatchTests.m */,
 			);
 			name = Specs;
+			sourceTree = "<group>";
+		};
+		E063DD921CAACB3F00E55764 /* Batch */ = {
+			isa = PBXGroup;
+			children = (
+				E063DD961CAACD0600E55764 /* WABatchManager.h */,
+				E063DD971CAACD0600E55764 /* WABatchManager.m */,
+				E063DD931CAACB5800E55764 /* WABatchSession.h */,
+				E063DD941CAACB5800E55764 /* WABatchSession.m */,
+				E063DD991CAACF0A00E55764 /* WABatchCache.h */,
+				E063DD9A1CAACF0A00E55764 /* WABatchCache.m */,
+				E063DD9C1CAACF1400E55764 /* WABatchObject.h */,
+				E063DD9D1CAACF1400E55764 /* WABatchObject.m */,
+				E00C83291CAC7C72004F3F1C /* WABatchResponse.h */,
+				E00C832A1CAC7C72004F3F1C /* WABatchResponse.m */,
+			);
+			name = Batch;
 			sourceTree = "<group>";
 		};
 		E09D02FC1C7D24B300938629 /* Fixtures */ = {
@@ -580,11 +627,15 @@
 				E01C1CD91C7CD6B100FFEF06 /* WANetworkRoute.m in Sources */,
 				E01C1CCF1C7CC02600FFEF06 /* WAObjectResponse.m in Sources */,
 				E01C1CE31C7CDA3000FFEF06 /* WARequestDescriptor.m in Sources */,
+				E063DD951CAACB5800E55764 /* WABatchSession.m in Sources */,
 				E01C1CDC1C7CD6BD00FFEF06 /* WANetworkRoutePattern.m in Sources */,
 				E04C8E2D1CA0798000D51D2C /* WAProgress.m in Sources */,
+				E063DD981CAACD0600E55764 /* WABatchManager.m in Sources */,
+				E063DD9E1CAACF1400E55764 /* WABatchObject.m in Sources */,
 				E01C1CC61C7CBBC800FFEF06 /* WAAFNetworkingRequestManager.m in Sources */,
 				E04C8E2A1C9EF4D400D51D2C /* Comment.m in Sources */,
 				E01C1CD21C7CC78000FFEF06 /* WAURLResponse.m in Sources */,
+				E00C832B1CAC7C72004F3F1C /* WABatchResponse.m in Sources */,
 				E04C8E271C9EF4CC00D51D2C /* CommentsTableViewController.m in Sources */,
 				E01C1CE61C7CDB3400FFEF06 /* WAMappingManager.m in Sources */,
 				E04C8E241C9DEA8100D51D2C /* WANetworkRoutingManager.m in Sources */,
@@ -594,6 +645,7 @@
 				E01C1CCB1C7CC00300FFEF06 /* WAObjectRequest.m in Sources */,
 				E01C1CD61C7CD6A700FFEF06 /* WANetworkRouter.m in Sources */,
 				E09D02F31C7D17E800938629 /* WANRBasicError.m in Sources */,
+				E063DD9B1CAACF0A00E55764 /* WABatchCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -603,8 +655,10 @@
 			files = (
 				E01C1CFA1C7CE7C500FFEF06 /* EnterpriseCD+CoreDataProperties.m in Sources */,
 				E01C1D061C7CEE5300FFEF06 /* WARouteURLTests.m in Sources */,
+				E063DDA31CAADDB000E55764 /* WABatchManagerTests.m in Sources */,
 				E01C1D021C7CE87600FFEF06 /* WANetworkRoutingManager.m in Sources */,
 				E01C1CF71C7CE7C500FFEF06 /* EmployeeCD+CoreDataProperties.m in Sources */,
+				E0F343211CAC30CA00055D0F /* WARoutingManagerRequestBatchTests.m in Sources */,
 				E01C1D0A1C7CF06C00FFEF06 /* WAResponseDescriptorTests.m in Sources */,
 				E01C1CF61C7CE7C500FFEF06 /* EmployeeCD.m in Sources */,
 				E01C1CFF1C7CE81B00FFEF06 /* WARouteTests.m in Sources */,
@@ -613,6 +667,8 @@
 				E01C1CFB1C7CE7C500FFEF06 /* Model.xcdatamodeld in Sources */,
 				E09D02FE1C7D421100938629 /* WARoutingManagerRequestMappingRouterTests.m in Sources */,
 				E01C1D081C7CEEEE00FFEF06 /* WAObjectRequestTests.m in Sources */,
+				E00C832D1CAC8BDD004F3F1C /* WARoutingManagerRequestMappingBatchTests.m in Sources */,
+				E063DDA11CAAD47A00E55764 /* WABatchCacheTests.m in Sources */,
 				E01C1CF81C7CE7C500FFEF06 /* Enterprise.m in Sources */,
 				E01C1CF91C7CE7C500FFEF06 /* EnterpriseCD.m in Sources */,
 				E01C1CF51C7CE7C500FFEF06 /* Employee.m in Sources */,

--- a/WANetworkRouting/AppDelegate.m
+++ b/WANetworkRouting/AppDelegate.m
@@ -95,7 +95,8 @@
     WANetworkRoutingManager *routingManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:@"http://jsonplaceholder.typicode.com"]
                                                                            requestManager:requestManager
                                                                            mappingManager:mappingManager
-                                                                    authenticationManager:nil];
+                                                                    authenticationManager:nil
+                                                                             batchManager:nil];
     
     // ———————————————————————————————————————————
     // Configure the router

--- a/WANetworkRoutingTests/Enterprise.m
+++ b/WANetworkRoutingTests/Enterprise.m
@@ -10,4 +10,8 @@
 
 @implementation Enterprise
 
+- (NSString *)description {
+    return [NSString stringWithFormat:@"%@ - %@", [super description], self.itemID];
+}
+
 @end

--- a/WANetworkRoutingTests/WABatchCacheTests.m
+++ b/WANetworkRoutingTests/WABatchCacheTests.m
@@ -1,0 +1,78 @@
+//
+//  WABatchCacheTests.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import <Kiwi/Kiwi.h>
+
+#import "WABatchCache.h"
+#import "WABatchObject.h"
+
+SPEC_BEGIN(WABatchCacheTests)
+
+describe(@"Register objects", ^{
+    WABatchCache *cache = [[WABatchCache alloc] init];
+    [cache dropDatabase];
+    
+    WABatchObject *batchObject1 = [[WABatchObject alloc] init];
+    batchObject1.uri            = @"/authentication";
+    batchObject1.method         = @"POST";
+    batchObject1.headers        = @{@"header1": @"Test"};
+    batchObject1.parameters     = @{@"param1": @1};
+
+    WABatchObject *batchObject2 = [[WABatchObject alloc] init];
+    batchObject2.uri            = @"/book";
+    batchObject2.method         = @"POST";
+    batchObject2.parameters     = @{@"param1": @1};
+    
+    [cache addBatchObject:batchObject1];
+    [cache addBatchObject:batchObject2];
+    
+    specify(^{
+        [[batchObject1.batchID should] equal:@1];
+        [[batchObject2.batchID should] equal:@2];
+        
+        [[[cache batchObjects] should] haveCountOf:2];
+    });
+    
+    specify(^{
+        [cache removeBatchObjects:@[batchObject1, batchObject2]];
+        [[[cache batchObjects] should] haveCountOf:0];
+        
+        WABatchObject *batchObject3 = [[WABatchObject alloc] init];
+        batchObject3.uri            = @"/book";
+        batchObject3.method         = @"POST";
+        batchObject3.headers        = @{@"header1": @"Test"};
+        batchObject3.parameters     = @{@"param1": @1};
+        
+        [cache addBatchObject:batchObject3];
+        [[batchObject3.batchID should] equal:@3];
+
+        [[[cache batchObjects] should] haveCountOf:1];
+    });
+    
+    specify(^{
+        [cache dropDatabase];
+        [[[cache batchObjects] should] haveCountOf:0];
+        
+        WABatchObject *batchObject4 = [[WABatchObject alloc] init];
+        batchObject4.uri            = @"/book";
+        batchObject4.method         = @"POST";
+        batchObject4.headers        = @{@"header1": @"Test"};
+        batchObject4.parameters     = @{@"param1": @1};
+        
+        [cache addBatchObject:batchObject4];
+        [[batchObject4.batchID should] equal:@1];
+        
+        [[[cache batchObjects] should] haveCountOf:1];
+    });
+    
+    specify(^{
+        [[[[[WABatchCache alloc] init] batchObjects] should] haveCountOf:1];
+    });
+});
+
+SPEC_END

--- a/WANetworkRoutingTests/WABatchManagerTests.m
+++ b/WANetworkRoutingTests/WABatchManagerTests.m
@@ -1,0 +1,94 @@
+//
+//  WABatchManagerTests.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 29/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+
+#import <Kiwi/Kiwi.h>
+
+#import "WABatchCache.h"
+#import "WABatchObject.h"
+#import "WAObjectRequest.h"
+#import "WANetworkRoute.h"
+
+#import "WABatchManager.h"
+
+SPEC_BEGIN(WABatchManagerTests)
+
+describe(@"Needs flushing", ^{
+    WABatchCache *cache = [[WABatchCache alloc] init];
+    [cache dropDatabase];
+    
+    WABatchObject *batchObject = [[WABatchObject alloc] init];
+    batchObject.uri            = @"/authentication";
+    batchObject.method         = @"POST";
+    batchObject.headers        = @{@"header1": @"Test"};
+    batchObject.parameters     = @{@"param1": @1};
+    
+    [cache addBatchObject:batchObject];
+    
+    specify(^{
+        WABatchManager *batchManager = [[WABatchManager alloc] initWithBatchPath:@"/batch" limit:1];
+        [[theValue([batchManager needsFlushing]) should] equal:@YES];
+    });
+    
+    specify(^{
+        [cache dropDatabase];
+        WABatchManager *batchManager = [[WABatchManager alloc] initWithBatchPath:@"/batch" limit:1];
+        [[theValue([batchManager needsFlushing]) should] equal:@NO];
+    });
+});
+
+describe(@"Can enqueue offline", ^{
+    WABatchManager *batchManager = [[WABatchManager alloc] initWithBatchPath:@"/batch" limit:1];
+    WAObjectRequest *notEnqueuableRequest = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodGET
+                                                                              path:@"/authentication"
+                                                                        parameters:nil
+                                                                   optionalHeaders:nil];
+    
+    WAObjectRequest *notEnqueuableRequest2 = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodGET
+                                                                               path:@"/books"
+                                                                         parameters:nil
+                                                                    optionalHeaders:nil];
+    
+    WAObjectRequest *notEnqueuableRequest3 = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodPUT
+                                                                               path:@"/authors/1"
+                                                                         parameters:nil
+                                                                    optionalHeaders:nil];
+    
+    WAObjectRequest *enqueuableRequest1 = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodPOST
+                                                                            path:@"/books"
+                                                                      parameters:nil
+                                                                 optionalHeaders:nil];
+    
+    WAObjectRequest *enqueuableRequest2 = [WAObjectRequest requestWithHTTPMethod:WAObjectRequestMethodPUT
+                                                                            path:@"/books/1"
+                                                                      parameters:nil
+                                                                 optionalHeaders:nil];
+    
+    WANetworkRoute *postRoute = [WANetworkRoute routeWithObjectClass:nil
+                                                         pathPattern:@"/books"
+                                                              method:WAObjectRequestMethodPOST];
+    
+    WANetworkRoute *putRoute = [WANetworkRoute routeWithObjectClass:nil
+                                                        pathPattern:@"/books/1"
+                                                             method:WAObjectRequestMethodPUT];
+    
+    [batchManager addRouteToBatchIfOffline:postRoute];
+    [batchManager addRouteToBatchIfOffline:putRoute];
+    
+    specify(^{
+        [[theValue([batchManager canEnqueueOfflineRequest:notEnqueuableRequest]) should] equal:@NO];
+    });
+    
+    specify(^{
+        [[theValue([batchManager canEnqueueOfflineRequest:enqueuableRequest1]) should] equal:@YES];
+        [[theValue([batchManager canEnqueueOfflineRequest:enqueuableRequest2]) should] equal:@YES];
+        [[theValue([batchManager canEnqueueOfflineRequest:notEnqueuableRequest2]) should] equal:@NO];
+        [[theValue([batchManager canEnqueueOfflineRequest:notEnqueuableRequest3]) should] equal:@NO];
+    });
+});
+
+SPEC_END

--- a/WANetworkRoutingTests/WAObjectRequestTests.m
+++ b/WANetworkRoutingTests/WAObjectRequestTests.m
@@ -33,7 +33,7 @@ static NSString *kBaseURLSimple = @"http://www.someURL.com";
 static NSString *kBaseURLWithPaths = @"http://www.someURL.com/api/v2";
 
 describe(@"Create request with simple URL", ^{
-    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURLSimple] requestManager:nil mappingManager:nil authenticationManager:nil];
+    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURLSimple] requestManager:nil mappingManager:nil authenticationManager:nil batchManager:nil];
     
     WANetworkRoute *routeClassic = [WANetworkRoute routeWithObjectClass:[ObjectRequestTest class]
                                                             pathPattern:@"categories/:itemID"
@@ -76,7 +76,7 @@ describe(@"Create request with simple URL", ^{
 
 describe(@"Create request with URL subpaths", ^{
     
-    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURLWithPaths] requestManager:nil mappingManager:nil authenticationManager:nil];
+    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURLWithPaths] requestManager:nil mappingManager:nil authenticationManager:nil batchManager:nil];
     
     WANetworkRoute *routeClassic = [WANetworkRoute routeWithObjectClass:[ObjectRequestTest class]
                                                             pathPattern:@"categories/:itemID"

--- a/WANetworkRoutingTests/WARouteEqualityTests.m
+++ b/WANetworkRoutingTests/WARouteEqualityTests.m
@@ -17,7 +17,7 @@ SPEC_BEGIN(WARouteEquality)
 
 describe(@"Create two routes with the same parameters", ^{
         
-    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:@"http://www.someURL.com"] requestManager:nil mappingManager:nil authenticationManager:nil];
+    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:@"http://www.someURL.com"] requestManager:nil mappingManager:nil authenticationManager:nil batchManager:nil];
     
     WANetworkRoute *route1 = [WANetworkRoute routeWithObjectClass:[Enterprise class]
                                                       pathPattern:@"enterprises"
@@ -58,8 +58,8 @@ describe(@"Create two routes with the same parameters", ^{
     });
     
     WANetworkRoute *singleObjectGetRoute = [WANetworkRoute routeWithObjectClass:[Enterprise class]
-                                                        pathPattern:@"enterprise/:itemID"
-                                                             method:WAObjectRequestMethodGET];
+                                                                    pathPattern:@"enterprise/:itemID"
+                                                                         method:WAObjectRequestMethodGET];
     
     it(@"You can add two routes with the same method and class", ^{
         [[theBlock(^{
@@ -67,5 +67,33 @@ describe(@"Create two routes with the same parameters", ^{
         }) shouldNot] raise];
     });
 });
+
+describe(@"Create two routes with the same parameters but no class", ^{
+    
+    WANetworkRoute *route1 = [WANetworkRoute routeWithObjectClass:nil
+                                                      pathPattern:@"enterprises"
+                                                           method:WAObjectRequestMethodGET];
+    
+    WANetworkRoute *routeEqualTo1 = [WANetworkRoute routeWithObjectClass:nil
+                                                             pathPattern:@"enterprises"
+                                                                  method:WAObjectRequestMethodGET];
+    
+    WANetworkRoute *routeNotEqualTo1 = [WANetworkRoute routeWithObjectClass:nil
+                                                                pathPattern:@"enterprise"
+                                                                     method:WAObjectRequestMethodGET];
+    
+    it(@"1 and 1 should be equals", ^{
+        [[route1 should] equal:route1];
+    });
+    
+    it(@"1 and equalTo1 should be equals", ^{
+        [[route1 should] equal:routeEqualTo1];
+    });
+    
+    it(@"1 and notEqualTo1 should not be equals", ^{
+        [[route1 shouldNot] equal:routeNotEqualTo1];
+    });
+});
+
 
 SPEC_END

--- a/WANetworkRoutingTests/WARouteTests.m
+++ b/WANetworkRoutingTests/WARouteTests.m
@@ -16,7 +16,7 @@
 SPEC_BEGIN(WARouteTest)
 
 describe(@"Register a simple route", ^{
-    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:@"http://www.someURL.com"] requestManager:nil mappingManager:nil authenticationManager:nil];
+    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:@"http://www.someURL.com"] requestManager:nil mappingManager:nil authenticationManager:nil batchManager:nil];
     WANetworkRoute *routeGetAllEnterprises = [WANetworkRoute routeWithObjectClass:[Enterprise class]
                                                                       pathPattern:@"enterprises"
                                                                            method:WAObjectRequestMethodGET];

--- a/WANetworkRoutingTests/WARouteURLTests.m
+++ b/WANetworkRoutingTests/WARouteURLTests.m
@@ -26,7 +26,7 @@ static NSString *kBaseURL = @"http://www.someURL.com";
 
 describe(@"Get url paths from path pattern and object", ^{
     
-    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL] requestManager:nil mappingManager:nil authenticationManager:nil];
+    WANetworkRoutingManager *objectManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL] requestManager:nil mappingManager:nil authenticationManager:nil batchManager:nil];
     
     WANetworkRoute *routeClassic = [WANetworkRoute routeWithObjectClass:[RouteObjectTest class]
                                                             pathPattern:@"categories/:itemID"

--- a/WANetworkRoutingTests/WARoutingManagerRequestBatchTests.m
+++ b/WANetworkRoutingTests/WARoutingManagerRequestBatchTests.m
@@ -1,0 +1,150 @@
+//
+//  WARoutingManagerRequestBatchTests.m
+//  WANetworkRouting
+//
+//  Created by Marian Paul on 30/03/2016.
+//  Copyright © 2016 Wasappli. All rights reserved.
+//
+#import <Kiwi/Kiwi.h>
+
+#import "WANetworkRoutingManager.h"
+#import "WAAFNetworkingRequestManager.h"
+#import "WABatchManager.h"
+#import "WABatchCache.h"
+
+#import "WANetworkRoute.h"
+#import "WAObjectRequest.h"
+#import "WAObjectResponse.h"
+#import "WANRBasicError.h"
+#import "WAURLResponse.h"
+
+SPEC_BEGIN(RoutingManagerRequestBatchTests)
+
+static NSString *kBaseURL = @"http://www.someURL.com";
+
+describe(@"RoutingManagerRequestBatchTests", ^{
+    
+    __block WANetworkRoutingManager *routingManager = nil;
+    
+    beforeEach(^{
+        // ———————————————————————————————————————————
+        // Create the batch manager
+        // ———————————————————————————————————————————
+        WABatchManager *batchManager = [[WABatchManager alloc] initWithBatchPath:@"/batch" limit:1];
+        [batchManager reset];
+        
+        WANetworkRoute *postEnterprise = [WANetworkRoute routeWithObjectClass:nil
+                                                                  pathPattern:@"enterprises"
+                                                                       method:WAObjectRequestMethodPOST];
+        
+        WANetworkRoute *putPatchEnterprise = [WANetworkRoute routeWithObjectClass:nil
+                                                                      pathPattern:@"enterprises/:itemID"
+                                                                           method:WAObjectRequestMethodPUT|WAObjectRequestMethodPATCH];
+        
+        [batchManager addRouteToBatchIfOffline:postEnterprise];
+        [batchManager addRouteToBatchIfOffline:putPatchEnterprise];
+        
+        // ———————————————————————————————————————————
+        // Create the routing manager
+        // ———————————————————————————————————————————
+        WAAFNetworkingRequestManager *requestManager = [WAAFNetworkingRequestManager new];
+        
+        routingManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL]
+                                                      requestManager:requestManager
+                                                      mappingManager:nil
+                                               authenticationManager:nil
+                                                        batchManager:batchManager];
+        
+        // Stub reachability
+        [requestManager stub:@selector(isReachable) andReturn:theValue(NO)];
+    });
+    
+    it(@"should batch requests allowed to be batch", ^{
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@NO];
+        
+        [routingManager postObject:nil
+                              path:@"enterprises"
+                        parameters:nil
+                           success:nil
+                           failure:nil];
+        
+        [routingManager putObject:nil
+                             path:@"enterprises/1"
+                       parameters:nil
+                          success:nil
+                          failure:nil];
+        
+        [routingManager patchObject:nil
+                               path:@"enterprises/1"
+                         parameters:nil
+                            success:nil
+                            failure:nil];
+        
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@YES];
+        [[[[[WABatchCache alloc] init] batchObjects] should] haveCountOf:3];
+    });
+    
+    it(@"should not batch requests not allowed to be batch", ^{
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@NO];
+        
+        [routingManager postObject:nil
+                              path:@"employees"
+                        parameters:nil
+                           success:nil
+                           failure:nil];
+        
+        [routingManager putObject:nil
+                             path:@"employees/1"
+                       parameters:nil
+                          success:nil
+                          failure:nil];
+        
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@NO];
+        [[[[[WABatchCache alloc] init] batchObjects] should] haveCountOf:0];
+    });
+    
+    it(@"should return an error when the request is batched", ^{
+        __block id<WANRErrorProtocol> apiError = nil;
+        
+        [routingManager postObject:nil
+                              path:@"enterprises"
+                        parameters:nil
+                           success:nil
+                           failure:^(WAObjectRequest *objectRequest, WAObjectResponse *response, id<WANRErrorProtocol> error) {
+                               apiError = error;
+                           }];
+        
+        [[expectFutureValue([apiError originalError].domain) shouldEventually] equal:WANetworkRoutingManagerErrorDomain];
+        [[expectFutureValue(theValue([apiError originalError].code)) shouldEventually] equal:theValue(WANetworkRoutingManagerErrorRequestBatched)];
+    });
+    
+    it(@"should not batch requests allowed to be batch if online", ^{
+        // Stub reachability
+        [(WAAFNetworkingRequestManager *)routingManager.requestManager stub:@selector(isReachable) andReturn:theValue(YES)];
+        
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@NO];
+        
+        [routingManager postObject:nil
+                              path:@"enterprises"
+                        parameters:nil
+                           success:nil
+                           failure:nil];
+        
+        [routingManager putObject:nil
+                             path:@"enterprises/1"
+                       parameters:nil
+                          success:nil
+                          failure:nil];
+        
+        [routingManager patchObject:nil
+                               path:@"enterprises/1"
+                         parameters:nil
+                            success:nil
+                            failure:nil];
+        
+        [[theValue([routingManager.batchManager needsFlushing]) should] equal:@NO];
+        [[[[[WABatchCache alloc] init] batchObjects] should] haveCountOf:0];
+    });
+});
+
+SPEC_END

--- a/WANetworkRoutingTests/WARoutingManagerRequestMappingRouterTests.m
+++ b/WANetworkRoutingTests/WARoutingManagerRequestMappingRouterTests.m
@@ -113,7 +113,8 @@ describe(@"RoutingManagerRequestMappingRouterTests", ^{
         routingManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL]
                                                       requestManager:requestManager
                                                       mappingManager:mappingManager
-                                               authenticationManager:nil];
+                                               authenticationManager:nil
+                          batchManager:nil];
         
         // ———————————————————————————————————————————
         // Configure the router

--- a/WANetworkRoutingTests/WARoutingManagerRequestOnlyTests.m
+++ b/WANetworkRoutingTests/WARoutingManagerRequestOnlyTests.m
@@ -24,15 +24,16 @@ SPEC_BEGIN(RoutingManagerRequestOnlyTests)
 static NSString *kBaseURL = @"http://www.someURL.com";
 
 describe(@"RoutingManagerRequestOnlyTests", ^{
-
+    
     __block WANetworkRoutingManager *routingManager = nil;
     
     beforeAll(^{
-WAAFNetworkingRequestManager *requestManager = [WAAFNetworkingRequestManager new];
-routingManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL]
-                                                                       requestManager:requestManager
-                                                                       mappingManager:nil
-                                                                authenticationManager:nil];
+        WAAFNetworkingRequestManager *requestManager = [WAAFNetworkingRequestManager new];
+        routingManager = [WANetworkRoutingManager managerWithBaseURL:[NSURL URLWithString:kBaseURL]
+                                                      requestManager:requestManager
+                                                      mappingManager:nil
+                                               authenticationManager:nil
+                                                        batchManager:nil];
         
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
             return [request.URL.path isEqualToString:@"/enterprises"];


### PR DESCRIPTION
- Added Batch manager
- Fixed an issue on route and `DELETE`: the object is no longer mapped as a request
- Fixed an issue on request descriptors and routes with keypath. You can now write `meetings/:meeting.itemID/privatenotes/:itemID`
- Added reachability on `WARequestManagerProtocol` and `WAAFNetworkingRequestManager`: `isReachable`
- When you delete an object without using routes|request descriptors, the path is parsed to get the object ID to delete. It was not deleted before
- Fixed crashes when object requests have no success or failure blocks
- Fixed a crash when your request descriptor have no `shouldMapBlock`
